### PR TITLE
Use the original repo for bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,4 +40,7 @@
 	"engines": {
 		"node": ">= 0.8.15"
 	}
+        "bugs": {
+          "url": "https://github.com/gabelerner/canvg/issues"
+        }
 }


### PR DESCRIPTION
Maybe we can all agree on a single repo/npm name https://github.com/gabelerner/canvg/pull/477
